### PR TITLE
Fix instructions how to start the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ yarn
 Run with:
 
 ```sh 
-exp start
+expo start
 ```


### PR DESCRIPTION
"exp start" doesn't work anymore due to the rename of "exp" to "expo".